### PR TITLE
Add libgirepository-2.0-dev as dependency for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ by gtk4-layer-shell.
 Debian/Ubuntu:
 
 ```
-sudo apt install libgirepository-1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-4.0 libgtk4-layer-shell-dev
+sudo apt install libgirepository-1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-4.0 libgtk4-layer-shell-dev libgirepository-2.0-dev
 pip install pygobject
 ```
 


### PR DESCRIPTION
Without the dependency I get the following build failure:

[screen-exchange.txt](https://github.com/user-attachments/files/21545663/screen-exchange.txt)
